### PR TITLE
Get rid of deprecation warning

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,5 +1,5 @@
 ipywidgets>=7.0.0
 ipydatawidgets>=3.2.0
 git+git://github.com/yt-project/yt.git#egg=yt
-matplotlib<=3.1.3
+matplotlib>=3.1.3
 unyt

--- a/widgyts/colormaps.py
+++ b/widgyts/colormaps.py
@@ -18,7 +18,7 @@ class ColormapContainer(ipywidgets.Widget):
         colormaps = {}
         import matplotlib.cm as mplcm
 
-        cmap_list = mplcm.cmap_d.keys()
+        cmap_list = mplcm._cmap_registry.keys()
         for colormap in cmap_list:
             cmap = mplcm.get_cmap(colormap)
             vals = (cmap(np.mgrid[0.0:1.0:256j]) * 255).astype("uint8")


### PR DESCRIPTION
I believe this is the way to eliminate our constant cmap deprecation warning.
