### PR TITLE
Add different options of colormaps to the viewer

### DIFF
--- a/widgyts/dataset_viewer.py
+++ b/widgyts/dataset_viewer.py
@@ -78,6 +78,14 @@ class AMRDomainViewer(DomainViewer):
     r2_falloff = traitlets.Instance(pythreejs.Texture)
     colormap_texture = traitlets.Instance(pythreejs.Texture)
     cmap_truncate = traitlets.CFloat(0.5)
+    grid_colormap = traitlets.Unicode()
+
+    @traitlets.observe('grid_colormap')
+    def _update_grid_colormap(self, change):
+        cmap = mcm.get_cmap(change['new'])
+        for level, segments in enumerate(self.grid_views):
+            color = mcolors.to_hex(cmap(self.cmap_truncate * level / self.ds.max_level))
+            segments.material.color = color
 
     @traitlets.default("grid_views")
     def _grid_views_default(self):
@@ -181,17 +189,33 @@ class AMRDomainViewer(DomainViewer):
             )
             ipywidgets.jslink((line_slider, "value"), (view.material, "linewidth"))
             grid_contents.extend([visible, color_picker, line_slider])
+
+        dropdown = ipywidgets.Dropdown(
+            options = ['inferno', 'viridis', 'plasma', 'magma', 'cividis'],
+            value = 'inferno',
+            description = 'Colormap:', 
+            disable = False,
+
+        )
+
+        traitlets.link((dropdown, 'value'),(self, 'grid_colormap'))
+
         return ipywidgets.HBox(
             [
                 self.renderer,
-                ipywidgets.GridBox(
-                    grid_contents,
-                    layout=ipywidgets.Layout(
-                        width=r"50%",
-                        grid_template_columns=r"30% 10% auto",
-                        align_items="stretch",
+                ipywidgets.VBox([
+                    dropdown, 
+                    ipywidgets.GridBox(
+                        grid_contents,
+                        layout=ipywidgets.Layout(
+                            width=r"60%",
+                            grid_template_columns=r"30% 10% auto",
+                            align_items="stretch",
                     ),
                 ),
+            
+            ]
+        )
             ]
         )
 

--- a/widgyts/dataset_viewer.py
+++ b/widgyts/dataset_viewer.py
@@ -80,9 +80,9 @@ class AMRDomainViewer(DomainViewer):
     cmap_truncate = traitlets.CFloat(0.5)
     grid_colormap = traitlets.Unicode()
 
-    @traitlets.observe('grid_colormap')
+    @traitlets.observe("grid_colormap")
     def _update_grid_colormap(self, change):
-        cmap = mcm.get_cmap(change['new'])
+        cmap = mcm.get_cmap(change["new"])
         for level, segments in enumerate(self.grid_views):
             color = mcolors.to_hex(cmap(self.cmap_truncate * level / self.ds.max_level))
             segments.material.color = color
@@ -191,31 +191,30 @@ class AMRDomainViewer(DomainViewer):
             grid_contents.extend([visible, color_picker, line_slider])
 
         dropdown = ipywidgets.Dropdown(
-            options = ['inferno', 'viridis', 'plasma', 'magma', 'cividis'],
-            value = 'inferno',
-            description = 'Colormap:', 
-            disable = False,
-
+            options=["inferno", "viridis", "plasma", "magma", "cividis"],
+            value="inferno",
+            description="Colormap:",
+            disable=False,
         )
 
-        traitlets.link((dropdown, 'value'),(self, 'grid_colormap'))
+        traitlets.link((dropdown, "value"), (self, "grid_colormap"))
 
         return ipywidgets.HBox(
             [
                 self.renderer,
-                ipywidgets.VBox([
-                    dropdown, 
-                    ipywidgets.GridBox(
-                        grid_contents,
-                        layout=ipywidgets.Layout(
-                            width=r"60%",
-                            grid_template_columns=r"30% 10% auto",
-                            align_items="stretch",
-                    ),
+                ipywidgets.VBox(
+                    [
+                        dropdown,
+                        ipywidgets.GridBox(
+                            grid_contents,
+                            layout=ipywidgets.Layout(
+                                width=r"60%",
+                                grid_template_columns=r"30% 10% auto",
+                                align_items="stretch",
+                            ),
+                        ),
+                    ]
                 ),
-            
-            ]
-        )
             ]
         )
 


### PR DESCRIPTION
Users are able to choose different colormaps for the grid through the dropdown list and the colormaps will be updated each time the user changes the colormap option.