### PR TITLE
remove unneeded lint_requirements.txt

### DIFF
--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -1,8 +1,0 @@
-flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
-mccabe~=0.6.1
-pycodestyle~=2.6.0
-pyflakes~=2.2.0
-isort==5.6.4   # keep in sync with .pre-commit-config.yaml
-black==19.10b0 # keep in sync with .pre-commit-config.yaml
-flake8-bugbear
-flynt==0.52    # keep in sync with .pre-commit-config.yaml


### PR DESCRIPTION
pre-commit.ci is running the pre-commit checks, only `.pre-commit-config.yaml` is needed.

Close out #103 when this goes in.